### PR TITLE
Fixes the issue with caching in `imageWithPDFNamed`

### DIFF
--- a/UIImage+Vector/UIImage+Vector.m
+++ b/UIImage+Vector/UIImage+Vector.m
@@ -134,6 +134,8 @@
         UIGraphicsEndImageContext();
     }
 
+	[[self cache] setObject:image forKey:identifier];
+
     return image;
 }
 


### PR DESCRIPTION
Similar to the `iconWithFont` method a cache is consulted first in `imageWithPDFNamed`, but the line putting newly generated image into the cache was missing. This PR adds it.
